### PR TITLE
Move the point forward till a word is found.

### DIFF
--- a/string-inflection.el
+++ b/string-inflection.el
@@ -30,6 +30,7 @@
 ;;; Code:
 
 (defconst string-inflection-word-chars "a-zA-Z0-9_")
+(defconst string-inflection-non-word-chars (concat "^" string-inflection-word-chars))
 
 ;;--------------------------------------------------------------------------------
 
@@ -88,6 +89,7 @@
 (defun string-inflection-get-current-word ()
   "Gets the symbol near the cursor"
   (interactive)
+  (skip-chars-forward string-inflection-non-word-chars)
   (let ((start (progn
                  (skip-chars-forward string-inflection-word-chars)
                  (point)))


### PR DESCRIPTION
This behavior is in line with upcase-word, capitalize-word, etc.