### PR TITLE
Move the point forward till a word is found. (updated)

### DIFF
--- a/string-inflection.el
+++ b/string-inflection.el
@@ -30,6 +30,7 @@
 ;;; Code:
 
 (defconst string-inflection-word-chars "a-zA-Z0-9_")
+(defconst string-inflection-non-word-chars (concat "^" string-inflection-word-chars))
 
 ;;--------------------------------------------------------------------------------
 
@@ -63,31 +64,33 @@
 (defun string-inflection-camelcase ()
   "FooBar format"
   (interactive)
-  (insert (string-inflection-camelcase-function (string-inflection-get-current-word))))
+  (insert (string-inflection-camelcase-function (string-inflection-get-current-word t))))
 
 ;;;###autoload
 (defun string-inflection-lower-camelcase ()
   "fooBar format"
   (interactive)
-  (insert (string-inflection-lower-camelcase-function (string-inflection-get-current-word))))
+  (insert (string-inflection-lower-camelcase-function (string-inflection-get-current-word t))))
 
 ;;;###autoload
 (defun string-inflection-underscore ()
   "foo_bar format"
   (interactive)
-  (insert (string-inflection-underscore-function (string-inflection-get-current-word))))
+  (insert (string-inflection-underscore-function (string-inflection-get-current-word t))))
 
 ;;;###autoload
 (defun string-inflection-upcase ()
   "FOO_BAR format"
   (interactive)
-  (insert (string-inflection-upcase-function (string-inflection-get-current-word))))
+  (insert (string-inflection-upcase-function (string-inflection-get-current-word t))))
 
 ;;--------------------------------------------------------------------------------
 
-(defun string-inflection-get-current-word ()
-  "Gets the symbol near the cursor"
+(defun string-inflection-get-current-word (&optional skip)
+  "Gets the symbol near the cursor.  If SKIP is non-nil, skip non-word characters forward."
   (interactive)
+  (and skip
+       (skip-chars-forward string-inflection-non-word-chars))
   (let ((start (progn
                  (skip-chars-forward string-inflection-word-chars)
                  (point)))


### PR DESCRIPTION
This makes `string-inflection-camelcase`,
`string-inflection-underscore`, `string-inflection-upcase`, and
`string-inflection-downcase` behave like upcase-word, capitalize-word,
etc. while keeping cyclic and toggling functions intact.