### PR TITLE
Fix string-inflection-non-word-chars function bug

### DIFF
--- a/string-inflection.el
+++ b/string-inflection.el
@@ -136,11 +136,14 @@
 
 ;; --------------------------------------------------------------------------------
 
+(defun string-inflection-non-word-chars ()
+  (concat "^" string-inflection-word-chars))
+
 (defun string-inflection-get-current-word (&optional skip)
   "Gets the symbol near the cursor.  If SKIP is non-nil, skip non-word characters forward."
   (interactive)
   (and skip
-       (skip-chars-forward string-inflection-non-word-chars))
+       (skip-chars-forward (string-inflection-non-word-chars)))
   (let ((start (progn
                  (skip-chars-forward string-inflection-word-chars)
                  (point)))
@@ -150,9 +153,6 @@
     (prog1
         (buffer-substring start end)
       (delete-region start end))))
-
-(defun string-inflection-non-word-chars ()
-  (concat "^" string-inflection-word-chars))
 
 ;; --------------------------------------------------------------------------------
 


### PR DESCRIPTION
This was previously a constant variable, and referenced as such,
which broke when it became a function.

Fixes https://github.com/akicho8/string-inflection/issues/16