### PR TITLE
(feat) Skip backward after inflection based on a condition

### DIFF
--- a/string-inflection.el
+++ b/string-inflection.el
@@ -69,10 +69,16 @@
 ;;             '(lambda ()
 ;;                (local-set-key (kbd "C-c C-u") 'string-inflection-java-style-cycle)))
 ;;
+;; You may also consider setting `string-inflection-skip-backward-when-done' to
+;; `t' if you don't like `string-inflect' moving your point to the end of the
+;; word
 
 ;;; Code:
 
 (defconst string-inflection-word-chars "a-zA-Z0-9_-")
+
+(defvar string-inflection-skip-backward-when-done nil
+  "Whether point just move backward to the beginning of the word after inflecting.")
 
 ;; --------------------------------------------------------------------------------
 
@@ -80,7 +86,8 @@
 (defun string-inflection-ruby-style-cycle ()
   "foo_bar => FOO_BAR => FooBar => foo_bar"
   (interactive)
-  (insert (string-inflection-ruby-style-cycle-function (string-inflection-get-current-word))))
+  (string-inflection-insert
+   (string-inflection-ruby-style-cycle-function (string-inflection-get-current-word))))
 
 (fset 'string-inflection-cycle 'string-inflection-ruby-style-cycle)
 
@@ -88,53 +95,65 @@
 (defun string-inflection-java-style-cycle ()
   "fooBar => FOO_BAR => FooBar => fooBar"
   (interactive)
-  (insert (string-inflection-java-style-cycle-function (string-inflection-get-current-word))))
+  (string-inflection-insert
+   (string-inflection-java-style-cycle-function (string-inflection-get-current-word))))
 
 ;;;###autoload
 (defun string-inflection-all-cycle ()
   "foo_bar => FOO_BAR => FooBar => fooBar => foo-bar => foo_bar"
   (interactive)
-  (insert (string-inflection-all-cycle-function (string-inflection-get-current-word))))
+  (string-inflection-insert
+   (string-inflection-all-cycle-function (string-inflection-get-current-word))))
 
 ;;;###autoload
 (defun string-inflection-toggle ()
   "toggle foo_bar <=> FooBar"
   (interactive)
-  (insert (string-inflection-toggle-function (string-inflection-get-current-word))))
+  (string-inflection-insert
+   (string-inflection-toggle-function (string-inflection-get-current-word))))
 
 ;;;###autoload
 (defun string-inflection-camelcase ()
   "FooBar format"
   (interactive)
-  (insert (string-inflection-camelcase-function (string-inflection-get-current-word t))))
+  (string-inflection-insert
+   (string-inflection-camelcase-function (string-inflection-get-current-word t))))
 
 ;;;###autoload
 (defun string-inflection-lower-camelcase ()
   "fooBar format"
   (interactive)
-  (insert (string-inflection-lower-camelcase-function (string-inflection-get-current-word t))))
+  (string-inflection-insert
+   (string-inflection-lower-camelcase-function (string-inflection-get-current-word t))))
 
 ;;;###autoload
 (defun string-inflection-underscore ()
   "foo_bar format"
   (interactive)
-  (insert (string-inflection-underscore-function (string-inflection-get-current-word t))))
+  (string-inflection-insert
+   (string-inflection-underscore-function (string-inflection-get-current-word t))))
 
 ;;;###autoload
 (defun string-inflection-upcase ()
   "FOO_BAR format"
   (interactive)
-  (insert (string-inflection-upcase-function (string-inflection-get-current-word t))))
+  (string-inflection-insert
+   (string-inflection-upcase-function (string-inflection-get-current-word t))))
 
 ;;;###autoload
 (defun string-inflection-kebab-case ()
   "foo-bar format"
   (interactive)
-  (insert (string-inflection-kebab-case-function (string-inflection-get-current-word t))))
+  (string-inflection-insert
+   (string-inflection-kebab-case-function (string-inflection-get-current-word t))))
 
 (fset 'string-inflection-lisp 'string-inflection-kebab-case)
 
 ;; --------------------------------------------------------------------------------
+
+(defun string-inflection-insert (s)
+  (insert s)
+  (when string-inflection-skip-backward-when-done (skip-chars-backward string-inflection-word-chars)))
 
 (defun string-inflection-non-word-chars ()
   (concat "^" string-inflection-word-chars))


### PR DESCRIPTION
First of all, thanks for this helpful package!

I have a little improvement to make. I find it often strange that string inflection will move my point after the word when I position my point to be before the word before inflecting, but I understand that some people might prefer the existing behavior, so I've made a variable that when set to t, all the autoloaded functions will move the point back to the beginning of the word.
