### PR TITLE
Add `Capital_Underscore_Form`

### DIFF
--- a/README.org
+++ b/README.org
@@ -78,7 +78,7 @@ In the case of =string-inflection-java-style-cycle=
 
 In the case of =string-inflection-all-cycle=
 
-   : emacs_lisp => EMACS_LISP => EmacsLisp => emacsLisp => emacs-lisp => emacs_lisp
+   : emacs_lisp => EMACS_LISP => EmacsLisp => emacsLisp => emacs-lisp => Emacs_Lisp => emacs_lisp
 
 The =string-inflection-all-cycle=, conversion often. However,
 conversion occurs even when there is no need to lower-camelcase.
@@ -87,12 +87,14 @@ Therefore so difficult to use, is not recommended
 ** Function that can be used alone
 
 #+BEGIN_SRC elisp
-(string-inflection-underscore-function "EmacsLisp")       ; => "emacs_lisp"
-(string-inflection-pascal-case-function "emacs_lisp")     ; => "EmacsLisp"
-(string-inflection-camelcase-function "emacs_lisp")       ; => "emacsLisp"
-(string-inflection-upcase-function "emacs_lisp")          ; => "EMACS_LISP"
-(string-inflection-kebab-case-function "emacs_lisp")      ; => "emacs-lisp"
+(string-inflection-underscore-function "EmacsLisp")           ; => "emacs_lisp"
+(string-inflection-pascal-case-function "emacs_lisp")         ; => "EmacsLisp"
+(string-inflection-camelcase-function "emacs_lisp")           ; => "emacsLisp"
+(string-inflection-upcase-function "emacs_lisp")              ; => "EMACS_LISP"
+(string-inflection-kebab-case-function "emacs_lisp")          ; => "emacs-lisp"
+(string-inflection-capital-underscore-function "emacs_lisp")  ; => "Emacs_Lisp"
 
-(string-inflection-pascal-case-p "EmacsLisp")             ; => t
-(string-inflection-pascal-case-p "emacs_lisp")            ; => nil
+(string-inflection-pascal-case-p "EmacsLisp")                 ; => t
+(string-inflection-pascal-case-p "emacs_lisp")                ; => nil
+; etc...
 #+END_SRC

--- a/string-inflection.el
+++ b/string-inflection.el
@@ -28,7 +28,7 @@
 ;;   1. For Ruby -> string-inflection-ruby-style-cycle  (foo_bar => FOO_BAR => FooBar => foo_bar)
 ;;   2. For Python -> string-inflection-python-style-cycle  (foo_bar => FOO_BAR => FooBar => foo_bar)
 ;;   3. For Java -> string-inflection-java-style-cycle  (fooBar  => FOO_BAR => FooBar => fooBar)
-;;   4. For All  -> string-inflection-all-cycle         (foo_bar => FOO_BAR => FooBar => fooBar => foo-bar => foo_bar)
+;;   4. For All  -> string-inflection-all-cycle         (foo_bar => FOO_BAR => FooBar => fooBar => foo-bar => Foo_Bar => foo_bar)
 ;;
 ;;
 ;; Setting Example 1
@@ -116,7 +116,7 @@
 
 ;;;###autoload
 (defun string-inflection-all-cycle ()
-  "foo_bar => FOO_BAR => FooBar => fooBar => foo-bar => Foo_bar => foo_bar"
+  "foo_bar => FOO_BAR => FooBar => fooBar => foo-bar => Foo_Bar => foo_bar"
   (interactive)
   (string-inflection-insert
    (string-inflection-all-cycle-function (string-inflection-get-current-word))))

--- a/string-inflection.el
+++ b/string-inflection.el
@@ -116,7 +116,7 @@
 
 ;;;###autoload
 (defun string-inflection-all-cycle ()
-  "foo_bar => FOO_BAR => FooBar => fooBar => foo-bar => foo_bar"
+  "foo_bar => FOO_BAR => FooBar => fooBar => foo-bar => Foo_bar => foo_bar"
   (interactive)
   (string-inflection-insert
    (string-inflection-all-cycle-function (string-inflection-get-current-word))))
@@ -148,6 +148,13 @@
   (interactive)
   (string-inflection-insert
    (string-inflection-underscore-function (string-inflection-get-current-word t))))
+
+;;;###autoload
+(defun string-inflection-capital-underscore ()
+  "Foo_Bar format"
+  (interactive)
+  (string-inflection-insert
+   (string-inflection-capital-underscore-function (string-inflection-get-current-word t))))
 
 ;;;###autoload
 (defun string-inflection-upcase ()
@@ -226,6 +233,11 @@
     (setq str (replace-regexp-in-string "_+" "_" str))
     (downcase str)))
 
+(defun string-inflection-capital-underscore-function (str)
+  "foo_bar => Foo_Bar"
+  (setq str (string-inflection-underscore-function str))
+  (mapconcat 'capitalize (split-string str "_") "_"))
+
 (defun string-inflection-kebab-case-function (str)
   "foo_bar => foo-bar"
   (let ((case-fold-search nil))
@@ -233,7 +245,7 @@
     (setq str (replace-regexp-in-string "_" "-" str))))
 
 (defun string-inflection-all-cycle-function (str)
-  "foo_bar => FOO_BAR => FooBar => fooBar => foo-bar => foo_bar
+  "foo_bar => FOO_BAR => FooBar => fooBar => foo-bar => Foo_Bar => foo_bar
    foo     => FOO     => Foo    => foo"
   (cond
    ;; foo => FOO
@@ -252,6 +264,9 @@
    ;; fooBar => foo-bar
    ((string-inflection-camelcase-p str)
     (string-inflection-kebab-case-function str))
+   ;; foo-bar => Foo_Bar
+   ((string-inflection-kebab-case-p str)
+    (string-inflection-capital-underscore-function str))
    ;; foo-bar => foo_bar
    (t
     (string-inflection-underscore-function str))))
@@ -330,6 +345,14 @@
 (defun string-inflection-kebab-case-p (str)
   "if foo-bar => t"
   (string-match "-" str))
+
+(defun string-inflection-capital-underscore-p (str)
+  "if Foo_Bar => t"
+  (let ((case-fold-search nil))
+    (and
+     (string-match "[A-Z]" str)
+     (string-match "_" str)
+     (string-match "\\`[A-Z][a-zA-Z0-9_]+\\'" str))))
 
 (provide 'string-inflection)
 ;;; string-inflection.el ends here

--- a/test/string-inflection-test.el
+++ b/test/string-inflection-test.el
@@ -22,8 +22,10 @@
   (should (equal "FOO_BAR" (string-inflection-all-cycle-function "foo_bar")))
   (should (equal "FooBar" (string-inflection-all-cycle-function "FOO_BAR")))
   (should (equal "fooBar" (string-inflection-all-cycle-function "FooBar")))
-  (should (equal "foo_bar" (string-inflection-all-cycle-function "foo-bar")))
-  (should (equal "foo-bar" (string-inflection-all-cycle-function "fooBar"))))
+  (should (equal "fooBar" (string-inflection-all-cycle-function "FooBar")))
+  (should (equal "foo-bar" (string-inflection-all-cycle-function "fooBar")))
+  (should (equal "Foo_Bar" (string-inflection-all-cycle-function "foo-bar")))
+  (should (equal "foo_bar" (string-inflection-all-cycle-function "Foo_Bar"))))
 
 ; --------------------------------------------------------------------------------
 
@@ -67,6 +69,15 @@
   (should (equal "FOO1_BAR" (string-inflection-upcase-function "Foo1Bar")))
   (should (equal "FOO_BAR" (string-inflection-upcase-function "Foo_bar"))))
 
+(ert-deftest test-capital-underscore ()
+  (should (equal "Foo1_Bar" (string-inflection-capital-underscore-function "foo1_bar")))
+  (should (equal "Foo1_Bar" (string-inflection-capital-underscore-function "FOO1_BAR")))
+  (should (equal "Foo1bar" (string-inflection-capital-underscore-function "foo1bar")))
+  (should (equal "Foo1_Bar" (string-inflection-capital-underscore-function "foo1__bar")))
+  (should (equal "Foo1_Bar" (string-inflection-capital-underscore-function "Foo1Bar")))
+  (should (equal "Foo1_Bar" (string-inflection-capital-underscore-function "FOO1Bar")))
+  (should (equal "Foo_Bar" (string-inflection-capital-underscore-function "FOO_BAR"))))
+
 ;; --------------------------------------------------------------------------------
 
 (ert-deftest test-word-p ()
@@ -91,5 +102,8 @@
 
 (ert-deftest test-kebab-case-p ()
   (should-not (equal nil (string-inflection-kebab-case-p "foo-bar"))))
+
+(ert-deftest test-capital-underscore-p ()
+  (should-not (equal nil (string-inflection-capital-underscore-p "Foo_Bar"))))
 
 (ert-run-tests-batch t)


### PR DESCRIPTION
I use this form a few times in my code - not quite `UPCASE_FORM` but instead where the first character of each word is capitalized. The `string-inflection-capital-underscore-p` function I did could probably be better, but regex is not my forte...