### PR TITLE
Make string-inflection-get-current-word work more sensibly when transient mark mode is off

### DIFF
--- a/string-inflection.el
+++ b/string-inflection.el
@@ -184,19 +184,19 @@
 (defun string-inflection-get-current-word ()
   "Gets the symbol near the cursor"
   (interactive)
-  (let* ((start (if mark-active
+  (let* ((start (if (use-region-p)
                     (region-end)
                   (progn
                     (skip-chars-forward string-inflection-word-chars)
                     (point))))
-         (end (if mark-active
+         (end (if (use-region-p)
                   (region-beginning)
                 (progn
                   (skip-chars-backward string-inflection-word-chars)
                   (point))))
          (str (buffer-substring start end)))
     (prog1
-        (if mark-active
+        (if (use-region-p)
             (replace-regexp-in-string "[[:space:].:]+" "_" str) ; 'aa::bb.cc dd' => 'aa_bb_cc_dd'
           str)
       (delete-region start end))))


### PR DESCRIPTION
When transient mark mode is off 'mark-active' is effectively always true and string-inflection-get-current-word always returns a region even when the desired behavior is to operate on the word at point. use-region-p is the better test and produces the desired behavior both when transient-mode-mark is enabled and disabled.