### PR TITLE
Fix emacs native compilation warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /*.html
 ert.*
+*.elc

--- a/string-inflection.el
+++ b/string-inflection.el
@@ -107,11 +107,13 @@ the beginning."
 (defconst string-inflection-word-chars "a-zA-Z0-9_-")
 
 (defcustom string-inflection-erase-chars-when-region "./"
-  "When selected in the region, this character is included in the transformation as part of the string.
+  "When selected in the region, this character is included in the transformation
+as part of the string.
 
 Exactly assume that the underscore exists.
-For example, when you select `Foo/Bar', it is considered that `Foo_Bar' is selected.
-If include `:', select `FOO::VERSION' to run `M-x\ string-inflection-underscore' to `foo_version'."
+For example, when you select `Foo/Bar', it is considered that `Foo_Bar' is
+selected. If include `:', select `FOO::VERSION' to run
+`M-x\ string-inflection-underscore' to `foo_version'."
   :group 'string-inflection
   :type 'string)
 


### PR DESCRIPTION
```
 ■  Warning (comp): string-inflection.el:111:2: Warning:
custom-declare-variable `string-inflection-erase-chars-when-region'
docstring wider than 80 characters
```

To reproduce, have emacs built with native compilation and notice the compilation logs. You can then open the offending file and run `M-x emacs-lisp-native-compile-and-load` before and after the changes to see the warning is removed.