### PR TITLE
Implement `string-inflect-final-position`

### DIFF
--- a/README.org
+++ b/README.org
@@ -111,6 +111,12 @@ It is recommended that the major mode functions are used instead of =string-infl
 
 ** Region usage
 
-You can also use this library to convert a region's casing.
+You can also use this library to convert a region's casing.  That applies the
+operation to all symbols of the region.
 
 For that, simply select a region and perform =M-x string-inflection-kebab-case= (or any such other function).
+
+** Other configuration options
+
+You can configure where the cursor shall finish after the inflection operation
+using the =string-inflection-final-position= customization option.

--- a/README.org
+++ b/README.org
@@ -112,7 +112,8 @@ It is recommended that the major mode functions are used instead of =string-infl
 ** Region usage
 
 You can also use this library to convert a region's casing.  That applies the
-operation to all symbols of the region.
+operation to all symbols of the region. If a symbol is only partially covered
+by the region, the operation is performed only on that part.
 
 For that, simply select a region and perform =M-x string-inflection-kebab-case= (or any such other function).
 

--- a/string-inflection.el
+++ b/string-inflection.el
@@ -212,10 +212,9 @@ This can be `remain' – remain at the initial position but not beyond the end o
   "Perform INFLECT-FUNC for a  single occurrence."
   (let ((orig-point (point)))
     (insert (funcall inflect-func (string-inflection-get-current-word)))
-    (cond ((eq string-inflection-final-position 'remain)
-           (goto-char (min orig-point (cdr (bounds-of-thing-at-point 'symbol)))))
-          ((eq string-inflection-final-position 'beginning)
-           (goto-char (car (bounds-of-thing-at-point 'symbol)))))))
+    (pcase string-inflection-final-position
+      ('remain (goto-char (min orig-point (cdr (bounds-of-thing-at-point 'symbol)))))
+      ('beginning (goto-char (car (bounds-of-thing-at-point 'symbol)))))))
 
 (defun string-inflection--region (inflect-func)
   "Perform INFLECT-FUNC for all occurrences in the region."
@@ -230,12 +229,10 @@ This can be `remain' – remain at the initial position but not beyond the end o
         (if-let* ((bounds (bounds-of-thing-at-point 'symbol)))
             (goto-char (car bounds)))))
     (let ((new-region
-           (cond ((eq string-inflection-final-position 'remain)
-                  (if (/= orig-point start)
-                      (cons start end)
-                    (cons end start)))
-           ((eq string-inflection-final-position 'beginning) (cons end start))
-           ((eq string-inflection-final-position 'end) (cons start end)))))
+           (pcase string-inflection-final-position
+             ('remain (if (/= orig-point start) (cons start end) (cons end start)))
+             ('beginning (cons end start))
+             ('end (cons start end)))))
       (set-mark (car new-region))
       (goto-char (cdr new-region)))
     (activate-mark)

--- a/string-inflection.el
+++ b/string-inflection.el
@@ -87,8 +87,8 @@
 ;;             '(lambda ()
 ;;                (local-set-key (kbd "C-c C-u") 'string-inflection-java-style-cycle)))
 ;;
-;; You can also set `string-inflection-skip-backward-when-done' to `t' if
-;; you don't like `string-inflect' moving your point to the end of the word.
+;; You can configure where the cursor should end up after the inflection using the
+;; `string-inflection-final-position' option.
 
 ;;; Code:
 

--- a/string-inflection.el
+++ b/string-inflection.el
@@ -98,7 +98,7 @@
 
 (defcustom string-inflection-final-position 'remain
   "Where to finish after the inflection.
-This can be `remain' – remain at the initial position –,
+This can be `remain' – remain at the initial position but not beyond the end of the inflected string –,
 `beginning' – jump to the beginning of the inflection – or
 `end' – jump to the end of the inflection."
   :group 'string-inflection
@@ -205,7 +205,7 @@ This can be `remain' – remain at the initial position –,
   (let ((orig-point (point)))
     (insert (funcall inflect-func (string-inflection-get-current-word)))
     (cond ((eq string-inflection-final-position 'remain)
-           (goto-char orig-point))
+           (goto-char (min orig-point (cdr (bounds-of-thing-at-point 'symbol)))))
           ((eq string-inflection-final-position 'beginning)
            (goto-char (car (bounds-of-thing-at-point 'symbol)))))))
 

--- a/test/string-inflection-test.el
+++ b/test/string-inflection-test.el
@@ -259,32 +259,35 @@
   (should (equal "eĥoŜanĝo->ĉiuĴaŭde" (buffer-try-inflect "eĥo_ŝanĝo->ĉiuĴaŭde" 'string-inflection-lower-camelcase))))
 
 
-(defun buffer-try-final-pos (str final-pos inflect)
+(defun buffer-try-final-pos (str final-pos inflect initial-pos)
   (with-temp-buffer
     (setq-local string-inflection-final-position final-pos)
     (insert (concat str " fooo"))
-    (goto-char 2)
+    (goto-char initial-pos)
     (funcall inflect)
     (should-not (use-region-p))
     (point)))
 
 (ert-deftest test-buffer-remain-simple-lengthen ()
-  (should (equal (buffer-try-final-pos "FooBar" 'remain #'string-inflection-underscore) 2)))
+  (should (equal (buffer-try-final-pos "FooBar" 'remain #'string-inflection-underscore 2) 2)))
 
 (ert-deftest test-buffer-end-simple-lengthen ()
-  (should (equal (buffer-try-final-pos "FooBar" 'end #'string-inflection-underscore) 8)))
+  (should (equal (buffer-try-final-pos "FooBar" 'end #'string-inflection-underscore 2) 8)))
 
 (ert-deftest test-buffer-beginning-simple-lengthen ()
-  (should (equal (buffer-try-final-pos "FooBar" 'beginning #'string-inflection-underscore) 1)))
+  (should (equal (buffer-try-final-pos "FooBar" 'beginning #'string-inflection-underscore 2) 1)))
 
-(ert-deftest test-buffer-remain-simple-shorten ()
-  (should (equal (buffer-try-final-pos "foo_bar" 'remain #'string-inflection-camelcase) 2)))
+(ert-deftest test-buffer-remain-simple-shorten-not-at-end ()
+  (should (equal (buffer-try-final-pos "foo_bar" 'remain #'string-inflection-camelcase 8) 7)))
+
+(ert-deftest test-buffer-remain-simple-shorten-at-end ()
+  (should (equal (buffer-try-final-pos "foo_bar" 'remain #'string-inflection-camelcase 2) 2)))
 
 (ert-deftest test-buffer-end-simple-shorten ()
-  (should (equal (buffer-try-final-pos "foo_bar" 'end #'string-inflection-camelcase) 7)))
+  (should (equal (buffer-try-final-pos "foo_bar" 'end #'string-inflection-camelcase 2) 7)))
 
 (ert-deftest test-buffer-beginning-simple-shorten ()
-  (should (equal (buffer-try-final-pos "foo_bar" 'beginning #'string-inflection-camelcase) 1)))
+  (should (equal (buffer-try-final-pos "foo_bar" 'beginning #'string-inflection-camelcase 2) 1)))
 
 
 (defun region-try-final-pos (str final-pos inverse)
@@ -369,4 +372,4 @@
     (should (equal final-pos 1))))
 
 
-(ert-run-tests-batch t)
+;(ert-run-tests-batch t)

--- a/test/string-inflection-test.el
+++ b/test/string-inflection-test.el
@@ -180,10 +180,9 @@
   (with-temp-buffer
     (funcall (or mode-func #'fundamental-mode))
     (insert str)
-    (transient-mark-mode t)
-    (beginning-of-buffer)
-    (set-mark-command nil)
-    (end-of-buffer)
+    (set-mark (point-min))
+    (goto-char (point-max))
+    (activate-mark)
     (funcall (or inflect #'string-inflection-toggle))
     (buffer-string)))
 

--- a/test/string-inflection-test.el
+++ b/test/string-inflection-test.el
@@ -260,4 +260,21 @@
   (should (equal "eĥoŜanĝo->ĉiuĴaŭde" (buffer-try-inflect "eĥo_ŝanĝo->ĉiuĴaŭde" 'string-inflection-lower-camelcase))))
 
 
+(defun buffer-try-final-pos (str final-pos)
+  (with-temp-buffer
+    (setq-local string-inflection-final-position final-pos)
+    (insert str)
+    (goto-char 2)
+    (string-inflection-toggle)
+    (point)))
+
+(ert-deftest test-buffer-remain-simple ()
+  (should (equal (buffer-try-final-pos "FooBar" 'remain) 2)))
+
+(ert-deftest test-buffer-end-simple ()
+  (should (equal (buffer-try-final-pos "FooBar" 'end) 7)))
+
+(ert-deftest test-buffer-beginning-simple ()
+  (should (equal (buffer-try-final-pos "FooBar" 'beginning) 1)))
+
 (ert-run-tests-batch t)

--- a/test/string-inflection-test.el
+++ b/test/string-inflection-test.el
@@ -407,4 +407,4 @@
   (should (equal (cdr (mixed-region-cycle-try 20 41)) (cons 20 43))))
 
 
-;(ert-run-tests-batch t)
+(ert-run-tests-batch t)

--- a/test/string-inflection-test.el
+++ b/test/string-inflection-test.el
@@ -372,4 +372,39 @@
     (should (equal final-pos 1))))
 
 
+(defun mixed-region-cycle-try (start end)
+  (with-temp-buffer
+    (text-mode)
+    (insert "someFunction_to_do_SomeThing FoofooBarbarBarbarFoofoo")
+    (set-mark start)
+    (goto-char end)
+    (activate-mark)
+    (string-inflection-cycle)
+    (cons (buffer-string) (cons (region-beginning) (region-end)))))
+
+
+(ert-deftest test-mixed-symbol-cycle-region-1 ()
+  (should (equal (car (mixed-region-cycle-try 1 13))
+                 "some_function_to_do_SomeThing FoofooBarbarBarbarFoofoo")))
+
+
+(ert-deftest test-mixed-symbol-cycle-region-2 ()
+  (should (equal (car (mixed-region-cycle-try 14 19))
+                 "someFunction_TO_DO_SomeThing FoofooBarbarBarbarFoofoo")))
+
+
+(ert-deftest test-mixed-symbol-cycle-region-3 ()
+  (should (equal (car (mixed-region-cycle-try 20 29))
+                 "someFunction_to_do_some_thing FoofooBarbarBarbarFoofoo")))
+
+
+(ert-deftest test-mixed-symbol-cycle-region-4 ()
+  (should (equal (car (mixed-region-cycle-try 20 41))
+                 "someFunction_to_do_some_thing foofoo_barbarBarbarFoofoo")))
+
+
+(ert-deftest test-mixed-symbol-cycle-region-restore-region ()
+  (should (equal (cdr (mixed-region-cycle-try 20 41)) (cons 20 43))))
+
+
 ;(ert-run-tests-batch t)


### PR DESCRIPTION
Closes #42 

This introduces `string-inflect-final-position` as proposed in #42. Along with this the behavior for `(use-region-p)` has been improved. When a region is active the inflection operation now does the following:

* The operation is performed on all symbols in the region.
* The region remains active after the inflection.
* As the region remains active the `-cycle-` operations now make sense.